### PR TITLE
Support multiple servers in one Sensu check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+/.rakeTasks
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+### Changed
+- Mesos check supports multiple servers.
+
 ## [0.0.2] - 2015-07-14
+
 ### Changed
 - updated sensu-plugin gem to 1.2.0
 
@@ -16,4 +20,3 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - initial release
-

--- a/bin/check-mesos.rb
+++ b/bin/check-mesos.rb
@@ -29,11 +29,15 @@
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 
+# Mesos default ports are defined here: http://mesos.apache.org/documentation/latest/configuration
+MASTER_DEFAULT_PORT = '5050'
+SLAVE_DEFAULT_PORT = '5051'
+
 class MesosNodeStatus < Sensu::Plugin::Check::CLI
   option :server,
-         description: 'Mesos Host',
-         short: '-s SERVER',
-         long: '--server SERVER',
+         description: 'Mesos servers, comma separated',
+         short: '-s SERVER1,SERVER2,...',
+         long: '--server SERVER1,SERVER2,...',
          default: 'localhost'
 
   option :mode,
@@ -41,6 +45,12 @@ class MesosNodeStatus < Sensu::Plugin::Check::CLI
          short: '-m MODE',
          long: '--mode MODE',
          required: true
+
+  option :port,
+         description: "port (default #{MASTER_DEFAULT_PORT} for master, #{SLAVE_DEFAULT_PORT} for slave)",
+         short: '-p PORT',
+         long: '--port PORT',
+         required: false
 
   option :timeout,
          description: 'timeout in seconds',
@@ -50,25 +60,33 @@ class MesosNodeStatus < Sensu::Plugin::Check::CLI
          default: 5
 
   def run
-    case config[:mode]
+    mode = config[:mode]
+    servers = config[:server]
+    case mode
     when 'master'
-      port = '5050'
+      port = config[:port] || MASTER_DEFAULT_PORT
       uri = '/master/health'
     when 'slave'
-      port = '5051'
+      port = config[:port] || SLAVE_DEFAULT_PORT
       uri = '/slave(1)/health'
     end
-    begin
-      r = RestClient::Resource.new("http://#{config[:server]}:#{port}#{uri}", timeout: config[:timeout]).get
-      if r.code == 200
-        ok "Mesos #{config[:mode]} is up"
-      else
-        critical "Mesos #{config[:mode]} is not responding"
+    failures = []
+    servers.split(',').each do |server|
+      begin
+        r = RestClient::Resource.new("http://#{server}:#{port}#{uri}", timeout: config[:timeout]).get
+        if r.code != 200
+          failures << "#{config[:mode]} on #{server} is not responding"
+        end
+      rescue Errno::ECONNREFUSED, RestClient::ResourceNotFound, SocketError
+        failures << "Mesos #{mode} on #{server} is not responding"
+      rescue RestClient::RequestTimeout
+        failures << "Mesos #{mode} on #{server} connection timed out"
       end
-    rescue Errno::ECONNREFUSED
-      critical "Mesos #{config[:mode]} is not responding"
-    rescue RestClient::RequestTimeout
-      critical "Mesos #{config[:mode]} Connection timed out"
+    end
+    if failures.empty?
+      ok "Mesos #{mode} is running on #{servers}"
+    else
+      critical failures.join("\n")
     end
   end
 end


### PR DESCRIPTION
We run multiple mesos masters, and dozens of slaves.  When any go down
we want an alert.  Currently the Mesos check supports a single server
only.  This commit adds support for multiple servers, combining all the
error messages into a single result string.  It also adds support for
setting a port number.

I tested this locally with different options, but it would be nice
to have unit tests for the various options.  That would be quite a
big change given the current lack of tests, and the need for mock
Mesos servers, so I'm punting them to another commit.