### PR TITLE
Chronos check for Sensu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+/.rakeTasks
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased][unreleased]
+## Unreleased
 
 ### Added
 - Timeout option.
+- Mesos check supports multiple servers.
 
 ## 0.0.1 - 2015-05-21
 
 ### Added
 - initial release
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Timeout option.
 - Mesos check supports multiple servers.
+- Basic chronos check.
 
 ## 0.0.1 - 2015-05-21
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
  * bin/check-mesos.rb
  * bin/metrics-marathon.rb
  * bin/metrics-mesos.rb
+ * bin/check-chronos.rb
 
 ## Usage
 

--- a/bin/check-chronos.rb
+++ b/bin/check-chronos.rb
@@ -1,0 +1,64 @@
+#! /usr/bin/env ruby
+#
+#   check-chronos
+#
+# DESCRIPTION:
+#   This plugin checks that Chronos can query the existing job graph.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015, Tom Stockton (tom@stocktons.org.uk)
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+
+class ChronosNodeStatus < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'Chronos host',
+         short: '-s SERVER',
+         long: '--server SERVER',
+         default: 'localhost'
+
+  option :port,
+         description: 'Chronos port',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: '80'
+
+  option :timeout,
+         description: 'timeout in seconds',
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 5
+
+  def run
+    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/scheduler/jobs", timeout: config[:timeout]).get
+    if r.code == 200
+      ok 'Chronos Service is up'
+    else
+      critical 'Chronos Service is not responding'
+    end
+  rescue Errno::ECONNREFUSED, RestClient::ResourceNotFound
+    critical 'Chronos Service is not responding'
+  rescue RestClient::RequestTimeout
+    critical 'Chronos Service Connection timed out'
+  end
+end

--- a/bin/check-mesos.rb
+++ b/bin/check-mesos.rb
@@ -29,11 +29,15 @@
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 
+# Mesos default ports are defined here: http://mesos.apache.org/documentation/latest/configuration
+MASTER_DEFAULT_PORT = '5050'
+SLAVE_DEFAULT_PORT = '5051'
+
 class MesosNodeStatus < Sensu::Plugin::Check::CLI
   option :server,
-         description: 'Mesos Host',
-         short: '-s SERVER',
-         long: '--server SERVER',
+         description: 'Mesos servers, comma separated',
+         short: '-s SERVER1,SERVER2,...',
+         long: '--server SERVER1,SERVER2,...',
          default: 'localhost'
 
   option :mode,
@@ -41,6 +45,12 @@ class MesosNodeStatus < Sensu::Plugin::Check::CLI
          short: '-m MODE',
          long: '--mode MODE',
          required: true
+
+  option :port,
+         description: "port (default #{MASTER_DEFAULT_PORT} for master, #{SLAVE_DEFAULT_PORT} for slave)",
+         short: '-p PORT',
+         long: '--port PORT',
+         required: false
 
   option :timeout,
          description: 'timeout in seconds',
@@ -50,25 +60,33 @@ class MesosNodeStatus < Sensu::Plugin::Check::CLI
          default: 5
 
   def run
-    case config[:mode]
+    mode = config[:mode]
+    servers = config[:server]
+    case mode
     when 'master'
-      port = '5050'
+      port = config[:port] || MASTER_DEFAULT_PORT
       uri = '/master/health'
     when 'slave'
-      port = '5051'
+      port = config[:port] || SLAVE_DEFAULT_PORT
       uri = '/slave(1)/health'
     end
-    begin
-      r = RestClient::Resource.new("http://#{config[:server]}:#{port}#{uri}", timeout: config[:timeout]).get
-      if r.code == 200
-        ok "Mesos #{config[:mode]} is up"
-      else
-        critical "Mesos #{config[:mode]} is not responding"
+    failures = []
+    servers.split(',').each do |server|
+      begin
+        r = RestClient::Resource.new("http://#{server}:#{port}#{uri}", timeout: config[:timeout]).get
+        if r.code != 200
+          failures << "#{config[:mode]} on #{server} is not responding"
+        end
+      rescue Errno::ECONNREFUSED, RestClient::ResourceNotFound, SocketError
+        failures << "Mesos #{mode} on #{server} is not responding"
+      rescue RestClient::RequestTimeout
+        failures << "Mesos #{mode} on #{server} connection timed out"
       end
-    rescue Errno::ECONNREFUSED
-      critical "Mesos #{config[:mode]} is not responding"
-    rescue RestClient::RequestTimeout
-      critical "Mesos #{config[:mode]} Connection timed out"
+    end
+    if failures.empty?
+      ok "Mesos #{mode} is running on #{servers}"
+    else
+      critical failures.join("\n")
     end
   end
 end


### PR DESCRIPTION
This is a check for Chronos, similar to the other Mesosphere projects,
Mesos, and Marathon.  Chronos doesn't have a generic health endpoint
like /ping for mesos, so we query the job graph at /scheduler/jobs.

I manually tested running and non-running chronos. Though unit tests
would be preferable, mocking the Mesos infrastructure will be a
separate commit.