### PR TITLE
Chronos check for Sensu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - Mesos check supports multiple servers.
 
+### Added
+- Basic chronos check.
+
 ## [0.0.2] - 2015-07-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## Functionality
 
 ## Files
+ * bin/check-chronos.rb
  * bin/check-marathon.rb
  * bin/check-mesos.rb
  * bin/metrics-marathon.rb

--- a/bin/check-chronos.rb
+++ b/bin/check-chronos.rb
@@ -1,0 +1,73 @@
+#! /usr/bin/env ruby
+#
+#   check-chronos
+#
+# DESCRIPTION:
+#   This plugin checks that Chronos can query the existing job graph.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015, Tom Stockton (tom@stocktons.org.uk)
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+
+class ChronosNodeStatus < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'Chronos hosts, comma separated',
+         short: '-s SERVER',
+         long: '--server SERVER',
+         default: 'localhost'
+
+  option :port,
+         description: 'Chronos port',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: '80'
+
+  option :timeout,
+         description: 'timeout in seconds',
+         short: '-t TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 5
+
+  def run
+    servers = config[:server]
+    failures = []
+    servers.split(',').each do |server|
+      begin
+        r = RestClient::Resource.new("http://#{server}:#{config[:port]}/scheduler/jobs", timeout: config[:timeout]).get
+        if r.code != 200
+          failures << "Chronos on #{server} is not responding"
+        end
+      rescue Errno::ECONNREFUSED, RestClient::ResourceNotFound, SocketError
+        failures << "Chronos on #{server} is not responding"
+      rescue RestClient::RequestTimeout
+        failures << "Chronos on #{server} connection timed out"
+      end
+    end
+    if failures.empty?
+      ok "Chronos is running on #{servers}"
+    else
+      critical failures.join("\n")
+    end
+  end
+end


### PR DESCRIPTION
This is a check for Chronos, similar to the other Mesosphere projects,
Mesos, and Marathon.  Chronos doesn't have a generic health endpoint
like /ping for mesos, so we query the job graph at /scheduler/jobs.

I manually tested running and non-running chronos. Though unit tests
would be preferable, mocking the Mesos infrastructure will be a
separate commit.