### PR TITLE
Use correct parameter for retrieving running tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- check-marathon-task.rb: Rename incorrect "state" parameter to "status".
 
 ## [0.1.1] - 2016-03-04
 ### Added

--- a/bin/check-marathon-task.rb
+++ b/bin/check-marathon-task.rb
@@ -49,7 +49,7 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
     failures = []
     config[:server].split(',').each do |s|
       begin
-        url = URI.parse("http://#{s}:#{config[:port]}/v2/tasks?state=running")
+        url = URI.parse("http://#{s}:#{config[:port]}/v2/tasks?status=running")
         req = Net::HTTP::Get.new(url)
         req.add_field('Accept', 'application/json')
         r = Net::HTTP.new(url.host, url.port).start do |h|

--- a/sensu-plugins-mesos.gemspec
+++ b/sensu-plugins-mesos.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'json',                      '~> 1.8', '< 2.0'
 end


### PR DESCRIPTION
## Pull Request Checklist

This PR fixes the first part of #9. The incorrect `state` parameter is renamed to `status`.

There is a typo in the url used for the tasks API call. The state parameter doesn't exist and is replaced by this commit with status, which is the [correct parameter name][0].

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose

Making the `check-marathon-task.rb` plugin more reliable by only counting running tasks as "running properly".

#### Known Compatablity Issues

None

[0]: https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2-tasks