### PR TITLE
Add https support and authentication to marathon plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
@@ -26,7 +25,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 - check-marathon-task.rb: Use the health check results to verify that a task is running.
 - check-marathon-task.rb: Rename incorrect "state" parameter to "status".
+- Add https support and authentication to marathon plugins: (thanks to Erasys GmbH)
+    - Add "protocol" option to check-marathon and metrics-marathon
+    - Add "protocol", "username" and "password" options to check-marathon-task
 
 ## [0.1.1] - 2016-03-04
 ### Added

--- a/bin/check-marathon-task.rb
+++ b/bin/check-marathon-task.rb
@@ -50,20 +50,35 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
   option :server, short: '-s SERVER', long: '--server SERVER', required: true
   option :port, short: '-p PORT', long: '--port PORT', default: 8080
   option :task, short: '-t TASK', long: '--task TASK', required: true
-  option :instances, short: '-i INSTANCES', long: '--instances INSTANCES', required: true, proc: proc(&:to_i)
+  option :instances, short: '-i INSTANCES', long: '--instances INSTANCES',
+                     required: true, proc: proc(&:to_i)
+  option :protocol, short: '-P PROTOCOL', long: '--protocol PROTOCOL',
+                    required: false, default: 'http'
+  option :username, short: '-u USERNAME', long: '--username USERNAME',
+                    required: false
+  option :password, long: '--password PASSWORD', required: false
 
   def run
-    if config[:instances] == 0
+    if config[:instances].zero?
       unknown 'number of instances should be an integer'
+    end
+
+    if !config[:username].nil? && config[:password].nil? ||
+       config[:username].nil? && !config[:password].nil?
+      unknown 'You must provide both username and password'
     end
 
     failures = []
     config[:server].split(',').each do |s|
       begin
-        url = URI.parse("http://#{s}:#{config[:port]}/v2/tasks?status=running")
+        url = URI.parse("#{config[:protocol]}://#{s}:#{config[:port]}/v2/tasks?status=running")
         req = Net::HTTP::Get.new(url)
         req.add_field('Accept', 'application/json')
-        r = Net::HTTP.new(url.host, url.port).start do |h|
+        if !config[:username].nil? && !config[:password].nil?
+          req.basic_auth(config[:username], config[:password])
+        end
+        r = Net::HTTP.start(url.host, url.port,
+                            use_ssl: config[:protocol] == 'https') do |h|
           h.request(req)
         end
 

--- a/bin/check-marathon-task.rb
+++ b/bin/check-marathon-task.rb
@@ -50,11 +50,16 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
   option :server, short: '-s SERVER', long: '--server SERVER', required: true
   option :port, short: '-p PORT', long: '--port PORT', default: 8080
   option :task, short: '-t TASK', long: '--task TASK', required: true
-  option :instances, short: '-i INSTANCES', long: '--instances INSTANCES',
-                     required: true, proc: proc(&:to_i)
-  option :protocol, short: '-P PROTOCOL', long: '--protocol PROTOCOL',
-                    required: false, default: 'http'
-  option :username, short: '-u USERNAME', long: '--username USERNAME',
+  option :instances, short: '-i INSTANCES',
+                     long: '--instances INSTANCES',
+                     required: true,
+                     proc: proc(&:to_i)
+  option :protocol, short: '-P PROTOCOL',
+                    long: '--protocol PROTOCOL',
+                    required: false,
+                    default: 'http'
+  option :username, short: '-u USERNAME',
+                    long: '--username USERNAME',
                     required: false
   option :password, long: '--password PASSWORD', required: false
 

--- a/bin/check-marathon.rb
+++ b/bin/check-marathon.rb
@@ -43,6 +43,13 @@ class MarathonNodeStatus < Sensu::Plugin::Check::CLI
          required: false,
          default: '8080'
 
+  option :protocol,
+         description: 'Marathon protocol [http/https]',
+         short: '-P PROTOCOL',
+         long: '--protocol PROTOCOL',
+         required: false,
+         default: 'http'
+
   option :timeout,
          description: 'timeout in seconds',
          short: '-t TIMEOUT',
@@ -55,7 +62,7 @@ class MarathonNodeStatus < Sensu::Plugin::Check::CLI
     failures = []
     servers.split(',').each do |server|
       begin
-        r = RestClient::Resource.new("http://#{server}:#{config[:port]}/ping", timeout: config[:timeout]).get
+        r = RestClient::Resource.new("#{config[:protocol]}://#{server}:#{config[:port]}/ping", timeout: config[:timeout]).get
         if r.code != 200
           failures << "Marathon Service on #{server} is not responding"
         end

--- a/bin/metrics-marathon.rb
+++ b/bin/metrics-marathon.rb
@@ -54,6 +54,13 @@ class MarathonMetrics < Sensu::Plugin::Metric::CLI::Graphite
          required: false,
          default: '8080'
 
+  option :protocol,
+         description: 'Marathon protocol [http/https]',
+         short: '-P PROTOCOL',
+         long: '--protocol PROTOCOL',
+         required: false,
+         default: 'http'
+
   option :timeout,
          description: 'timeout in seconds',
          short: '-t TIMEOUT',
@@ -62,7 +69,7 @@ class MarathonMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: 5
 
   def run
-    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/metrics", timeout: config[:timeout]).get
+    r = RestClient::Resource.new("#{config[:protocol]}://#{config[:server]}:#{config[:port]}/metrics", timeout: config[:timeout]).get
     all_metrics = JSON.parse(r)
     metric_groups = all_metrics.keys - SKIP_ROOT_KEYS
     metric_groups.each do |metric_groups_key|


### PR DESCRIPTION
## Pull Request Checklist

This PR is not referring to an existing issue.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Add https support and authentication to marathon plugins:
- Add "protocol" option to check-marathon and metrics-marathon
- Add "protocol", "username" and "password" options to check-marathon-task
