### PR TITLE
Add option to inject Mesos master node role into metric fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ### Added
-- metrics-mesos.rb: Added metric in "Telegraf style" to note whether a master node is leader or standby
+- metrics-mesos.rb: Added option "include_role" to inject in metric fields whether a master node is leader or standby
 
 ## [Unreleased]
 ## [1.0.0] - 2017-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+### Added
+- metrics-mesos.rb: Added metric in "Telegraf style" to note whether a master node is leader or standby
+
 ## [Unreleased]
 ## [1.0.0] - 2017-05-05
 ### Breaking Change

--- a/bin/metrics-mesos.rb
+++ b/bin/metrics-mesos.rb
@@ -91,9 +91,9 @@ class MesosMetrics < Sensu::Plugin::Metric::CLI::Graphite
         output([scheme, k_copy].join('.'), v)
         next unless k_copy == 'master.elected' && config[:mode] == 'master'
         if v != 0.0
-          output([scheme, 'master.status'].join('.'), 'leader')
+          output([scheme, 'master.status.leader'].join('.'), 1)
         else
-          output([scheme, 'master.status'].join('.'), 'standby')
+          output([scheme, 'master.status.standby'].join('.'), 1)
         end
       end
     rescue Errno::ECONNREFUSED

--- a/bin/metrics-mesos.rb
+++ b/bin/metrics-mesos.rb
@@ -89,6 +89,12 @@ class MesosMetrics < Sensu::Plugin::Metric::CLI::Graphite
       JSON.parse(r).each do |k, v|
         k_copy = k.tr('/', '.')
         output([scheme, k_copy].join('.'), v)
+        next unless k_copy == 'master.elected' && config[:mode] == 'master'
+        if v != 0.0
+          output([scheme, 'master.status'].join('.'), 'leader')
+        else
+          output([scheme, 'master.status'].join('.'), 'standby')
+        end
       end
     rescue Errno::ECONNREFUSED
       critical "Mesos #{config[:mode]} is not responding"

--- a/bin/metrics-mesos.rb
+++ b/bin/metrics-mesos.rb
@@ -75,6 +75,12 @@ class MesosMetrics < Sensu::Plugin::Metric::CLI::Graphite
          proc: proc(&:to_i),
          default: 5
 
+  option :include_role,
+         description: 'Include master role in metrics',
+         short: '-r INCLUDE_ROLE',
+         long: '--host INCLUDE_ROLE',
+         default: 'false'
+
   def run
     uri = config[:uri]
     case config[:mode]
@@ -86,15 +92,19 @@ class MesosMetrics < Sensu::Plugin::Metric::CLI::Graphite
     scheme = "#{config[:scheme]}.mesos-#{config[:mode]}"
     begin
       r = RestClient::Resource.new("http://#{config[:server]}:#{port}#{uri}", timeout: config[:timeout]).get
-      JSON.parse(r).each do |k, v|
+      results = JSON.parse(r)
+      if config[:include_role] == 'true' && config[:mode] == 'master'
+        add_metric = if results['master/elected'] != 0.0
+                       'leader.'
+                     else
+                       'standby.'
+                     end
+      else
+        add_metric = ''
+      end
+      results.each do |k, v|
         k_copy = k.tr('/', '.')
-        output([scheme, k_copy].join('.'), v)
-        next unless k_copy == 'master.elected' && config[:mode] == 'master'
-        if v != 0.0
-          output([scheme, 'master.status.leader'].join('.'), 1)
-        else
-          output([scheme, 'master.status.standby'].join('.'), 1)
-        end
+        output([scheme, add_metric + k_copy].join('.'), v)
       end
     rescue Errno::ECONNREFUSED
       critical "Mesos #{config[:mode]} is not responding"


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

The purpose of this change is to use a different format for the shipped metrics, adding the role for the mesos master (either leader or standby) so then this plugin is used together with sensu-extensions-influxdb, the extension can add a tag for the role of the Mesos node queried.

To avoid breaking anything for people which is not using this extension, an option has been added, called 'include_role', which defaults to false so plugin behavior won't change. If the option is set to 'true' the plugin will inject the role into the metric fields. Then, from sensu-extensions-influxdb we can configure a template which allow us to tag the metric.

Example of an InfluxDB template definition without this feature:
"mesos-.*\\.": "measurement.group.field*"

Example of an InfluxDB template definition taking advantage of the feature and creating the tag "state":
"mesos-.*\\.": "measurement.state.group.field*"

This kind of metric tagging it's quite similar to the approach followed by Telegraf to tag Mesos metrics shipped to InfluxDB

#### Known Compatablity Issues
