### PR TITLE
check-marathon-task.rb gets number of configured instances in Marathon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
 - check-marathon-task.rb: if instances are not defined, plugin will check number of configured instances in Marathon. Also removed Net::HTTP in favour of Restclient::Resource
 
 ## [2.0.0] - 2017-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- check-marathon-task.rb: if instances are not defined, plugin will check number of configured instances in Marathon
+- check-marathon-task.rb: if instances are not defined, plugin will check number of configured instances in Marathon. Also removed Net::HTTP in favour of Restclient::Resource
 
 ## [2.0.0] - 2017-07-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- check-marathon-task.rb: if instances are not defined, plugin will check number of configured instances in Marathon
 
 ## [2.0.0] - 2017-07-15
 ### Added

--- a/bin/check-marathon-task.rb
+++ b/bin/check-marathon-task.rb
@@ -30,13 +30,13 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'net/http'
+require 'rest-client'
 require 'json'
 
 # This plugin checks that the given Mesos/Marathon task is running properly.
 #
 # This means that all of the following is true:
-# 1. There are N tasks for the app, as defined by the --instances parameter
+# 1. There are N tasks for the app, as defined by the --instances parameter or checks configured tasks in Marathon as fallback
 # 2. Each task's state is running
 # 3. No task is unhealthy, as defined in Marathon
 #
@@ -71,7 +71,8 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
   option :instances,
          short: '-i INSTANCES',
          long: '--instances INSTANCES',
-         required: true,
+         required: false,
+         default: 0,
          proc: proc(&:to_i)
 
   option :protocol,
@@ -89,11 +90,14 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
          long: '--password PASSWORD',
          required: false
 
-  def run
-    if config[:instances].zero?
-      unknown 'number of instances should be an integer'
-    end
+  option :timeout,
+         description: 'timeout in seconds',
+         short: '-T TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 5
 
+  def run
     if !config[:username].nil? && config[:password].nil? ||
        config[:username].nil? && !config[:password].nil?
       unknown 'You must provide both username and password'
@@ -103,28 +107,21 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
     uri = config[:uri]
     config[:server].split(',').each do |s|
       begin
-        url = URI.parse("#{config[:protocol]}://#{s}:#{config[:port]}#{uri}")
-        req = Net::HTTP::Get.new(url)
-        req.add_field('Accept', 'application/json')
-        if !config[:username].nil? && !config[:password].nil?
-          req.basic_auth(config[:username], config[:password])
-        end
-        r = Net::HTTP.start(url.host, url.port,
-                            use_ssl: config[:protocol] == 'https') do |h|
-          h.request(req)
-        end
+        auth_headers = {}
+        auth_headers = { Authorization: "#{config[:username]} #{config[:password]}" } if !config[:username].nil? && !config[:password].nil?
+        r = RestClient::Resource.new("#{config[:protocol]}://#{s}:#{config[:port]}#{uri}", auth_headers, config[:timeout]).get
+        expected = if config[:instances].zero?
+                     default_tasks(s)
+                   else
+                     config[:instances]
+                   end
+        ok_count, unhealthy = check_tasks r
 
-        ok_count, unhealthy = check_tasks r.body
+        message = "#{ok_count}/#{expected} #{config[:task]} tasks running"
 
-        message = "#{ok_count}/#{config[:instances]} #{config[:task]} tasks running"
+        message << ":\n" << unhealthy.join("\n") if unhealthy.any?
 
-        if unhealthy.any?
-          message << ":\n" << unhealthy.join("\n")
-        end
-
-        if unhealthy.any? || ok_count < config[:instances]
-          critical message
-        end
+        critical message if unhealthy.any? || ok_count < config[:instances]
 
         ok message
       rescue Errno::ECONNREFUSED, SocketError
@@ -172,5 +169,14 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
     end
 
     [tasks.length, unhealthy]
+  end
+
+  def default_tasks(server)
+    expected_tasks_url = "/v2/apps/#{config[:task]}"
+    auth_headers = {}
+    auth_headers = { Authorization: "#{config[:username]} #{config[:password]}" } if !config[:username].nil? && !config[:password].nil?
+    r = RestClient::Resource.new("#{config[:protocol]}://#{server}:#{config[:port]}#{expected_tasks_url}", auth_headers, config[:timeout]).get
+    n_tasks = JSON.parse(r)['app']['instances']
+    n_tasks
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

The idea is to give a default fallback to the check-marathon-task.rb for the expected number of instances, checking that number of instances on Marathon configuration. This allows to not modify the check definition when application is scaled up or down, providing a more generic check definition too. Previous behavior is observed, so if a number of instances is specified it will take precedence and configuration in Marathon won't be checked.

Also we realized this check was the only one using the net/http library, so for consistency shake we decided to replace it with rest-client library, as the rest of checks in the plugin.

Providing some output for the check in: https://gist.github.com/alcasim/cb6eeaff1c67cb80fa7525910315cb18

#### Known Compatibility Issues

