### PR TITLE
fixing bug with check-marathon-tasks.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- check-marathon-task.rb: solved a bug which prevented to alert when number of instances were retrieved from Marathon
 
 ## [2.1.0] - 2017-10-20
 ### Changed

--- a/bin/check-marathon-task.rb
+++ b/bin/check-marathon-task.rb
@@ -121,7 +121,7 @@ class MarathonTaskCheck < Sensu::Plugin::Check::CLI
 
         message << ":\n" << unhealthy.join("\n") if unhealthy.any?
 
-        critical message if unhealthy.any? || ok_count < config[:instances]
+        critical message if unhealthy.any? || ok_count < expected
 
         ok message
       rescue Errno::ECONNREFUSED, SocketError


### PR DESCRIPTION
so it will alarm when recovering number of tasks from marathon

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
On version 2.1.0 a feature was added to chech-marathon-tasks.rb, in order to retrieve the expected running tasks from mesos when a target is not specified in the check. We have started to use this feature and we have noticed the check is not alerting when using this feature and number of tasks is lower than expected, hence this small fix to solve it

Providing some output for this change:
https://gist.github.com/alcasim/f46c1758217513eca4767721baa6548c

I have also commented to @luisdavim the need of rewrite some tests for this plugin, for example, the problem fixed by this PR would have been spotted with proper testing, actual testing is not fully checking how the check works, only a part of it. @luisdavim proposal was to start adopting serverspec like in sensu-plugins-dcos.
#### Known Compatibility Issues

