### PR TITLE
ignore start/end keys in marathon metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-marathon.rb: ignore 2 new keys (start, end) in Marathon 1.5 /metrics endpoint
 
 ## [2.2.1] - 2017-11-04
 ### Fixed

--- a/bin/metrics-marathon.rb
+++ b/bin/metrics-marathon.rb
@@ -34,7 +34,7 @@ require 'socket'
 require 'json'
 
 class MarathonMetrics < Sensu::Plugin::Metric::CLI::Graphite
-  SKIP_ROOT_KEYS = %w(version).freeze
+  SKIP_ROOT_KEYS = %w(version start end).freeze
   option :scheme,
          description: 'Metric naming scheme',
          short: '-s SCHEME',


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets
**No update needed.**

- [x] Binstubs are created if needed
**No binstubs needed.**

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
With DC/OS 1.10.1, Marathon 1.5.1.2 is included and somewhere in marathon versions 1.4.7 to 1.5.1.2 there are 2 new fields (namely start and end) added to the marathon's  /metrics endpoint breaking the `metrics-marathon.rb` working. 

#### Known Compatibility Issues

None
